### PR TITLE
Add importing of os module to a sample of ipython_config.py in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $ ipython profile create spark
 Then adding the following line into `~/.ipython/profile_spark/ipython_config.py`:
 
 ```
+import os
 SPARK_HOME = os.environ['SPARK_HOME']
 # the above line can be replaced with: SPARK_HOME = '${INSERT_INSTALLATION_DIR_OF_SPARK}'
 MASTER = '${INSERT_YOUR_SPARK_MASTER_URL}'


### PR DESCRIPTION
I got an Exception about os module when I executed ipython command according to README.
I used Anaconda's ipython on CentOS7.

```
2014-12-02 21:15:13.141 [NotebookApp] ERROR | Exception while loading config file /home/dobachi/.ipython/profile_spark/ipython_config.py
Traceback (most recent call last):
  File "/home/dobachi/anaconda/lib/python2.7/site-packages/IPython/config/application.py", line 514, in _load_config_files
    config = loader.load_config()
  File "/home/dobachi/anaconda/lib/python2.7/site-packages/IPython/config/loader.py", line 425, in load_config
    self._read_file_as_dict()
  File "/home/dobachi/anaconda/lib/python2.7/site-packages/IPython/config/loader.py", line 478, in _read_file_as_dict
    py3compat.execfile(conf_filename, namespace)
  File "/home/dobachi/anaconda/lib/python2.7/site-packages/IPython/utils/py3compat.py", line 224, in execfile
    builtin_mod.execfile(filename, *where)
  File "/home/dobachi/.ipython/profile_spark/ipython_config.py", line 534, in <module>
    SPARK_HOME = os.environ['SPARK_HOME']
NameError: name 'os' is not defined
```

I needed `import os` before using `os.environ['SPARK_HOME']`.
How about it?
